### PR TITLE
Adding descriptions to archetypes

### DIFF
--- a/empty-plugin/pom.xml
+++ b/empty-plugin/pom.xml
@@ -9,4 +9,5 @@
     <groupId>io.jenkins.archetypes</groupId>
     <artifactId>empty-plugin</artifactId>
     <name>Empty Jenkins Plugin</name>
+    <description>Skeleton of a Jenkins plugin with a POM and an empty source tree.</description>
 </project>

--- a/scripted-pipeline/pom.xml
+++ b/scripted-pipeline/pom.xml
@@ -8,4 +8,5 @@
     </parent>
     <artifactId>scripted-pipeline</artifactId>
     <name>Scripted Jenkins Pipeline</name>
+    <description>Uses the Jenkins Pipeline Unit mock library to test the logic inside a Pipeline script.</description>
 </project>


### PR DESCRIPTION
Seems to be necessary to show some kind of information from `archetype:generate`.