### PR TITLE
Update plugin POMs to the latest versions

### DIFF
--- a/empty-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/empty-plugin/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.33</version>
+        <version>2.37</version>
         <relativePath />
     </parent>
     <artifactId>${artifactId}</artifactId>

--- a/hello-world/src/main/resources/archetype-resources/pom.xml
+++ b/hello-world/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.33</version>
+        <version>2.37</version>
         <relativePath />
     </parent>
     <artifactId>${artifactId}</artifactId>


### PR DESCRIPTION
Versions before 2.35 have issues with running JenkinsRule tests in IDEA, so I propose to fix that by just bumping versions.

@reviewbybees @jglick @Wadeck 