### PR TITLE
Use io.jenkins as the default package prefix for new code

### DIFF
--- a/empty-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/empty-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -13,10 +13,10 @@
             </includes>
         </fileSet>
         <fileSet>
-            <directory>src/main/java/org/jenkinsci/plugins</directory>
+            <directory>src/main/java/io/jenkins/plugins</directory>
         </fileSet>
         <fileSet>
-            <directory>src/test/java/org/jenkinsci/plugins</directory>
+            <directory>src/test/java/io/jenkins/plugins</directory>
         </fileSet>
     </fileSets>
     <requiredProperties>

--- a/empty-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/empty-plugin/src/main/resources/archetype-resources/pom.xml
@@ -7,6 +7,7 @@
         <version>2.37</version>
         <relativePath />
     </parent>
+    <groupId>io.jenkins.plugins</groupId>
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
     <packaging>hpi</packaging>

--- a/global-configuration/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/global-configuration/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -4,7 +4,7 @@
             <defaultValue>unused</defaultValue>
         </requiredProperty>
         <requiredProperty key="package">
-            <defaultValue>org.jenkinsci.plugins.sample</defaultValue>
+            <defaultValue>io.jenkins.plugins.sample</defaultValue>
         </requiredProperty>
     </requiredProperties>
     <fileSets>

--- a/global-configuration/src/main/resources/archetype-resources/pom.xml
+++ b/global-configuration/src/main/resources/archetype-resources/pom.xml
@@ -7,6 +7,7 @@
         <version>2.36</version>
         <relativePath />
     </parent>
+    <groupId>io.jenkins.plugins</groupId>
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
     <packaging>hpi</packaging>

--- a/global-configuration/src/test/resources/projects/testInstall/archetype.properties
+++ b/global-configuration/src/test/resources/projects/testInstall/archetype.properties
@@ -1,4 +1,4 @@
 groupId=IGNORED
 artifactId=testArtifact
 version=1.0-SNAPSHOT
-package=org.jenkinsci.plugins.sample
+package=io.jenkins.plugins.sample

--- a/global-shared-library/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/global-shared-library/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -7,7 +7,7 @@
             <defaultValue>org.sample</defaultValue>
         </requiredProperty>
         <requiredProperty key="package">
-            <defaultValue>org.jenkinsci.pipeline.sample</defaultValue>
+            <defaultValue>io.jenkins.pipeline.sample</defaultValue>
         </requiredProperty>
     </requiredProperties>
     <fileSets>

--- a/global-shared-library/src/test/resources/projects/testInstall/archetype.properties
+++ b/global-shared-library/src/test/resources/projects/testInstall/archetype.properties
@@ -1,4 +1,4 @@
 groupId=org.sample
 artifactId=testArtifact
 version=1.0-SNAPSHOT
-package=org.jenkinsci.pipeline.sample
+package=io.jenkins.pipeline.sample

--- a/hello-world/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/hello-world/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -4,7 +4,7 @@
             <defaultValue>unused</defaultValue>
         </requiredProperty>
         <requiredProperty key="package">
-            <defaultValue>org.jenkinsci.plugins.sample</defaultValue>
+            <defaultValue>io.jenkins.plugins.sample</defaultValue>
         </requiredProperty>
     </requiredProperties>
     <fileSets>

--- a/hello-world/src/main/resources/archetype-resources/pom.xml
+++ b/hello-world/src/main/resources/archetype-resources/pom.xml
@@ -7,6 +7,7 @@
         <version>2.37</version>
         <relativePath />
     </parent>
+    <groupId>io.jenkins.plugins</groupId>
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
     <packaging>hpi</packaging>

--- a/hello-world/src/test/resources/projects/testInstall/archetype.properties
+++ b/hello-world/src/test/resources/projects/testInstall/archetype.properties
@@ -1,4 +1,4 @@
 groupId=IGNORED
 artifactId=testArtifact
 version=1.0-SNAPSHOT
-package=org.jenkinsci.plugins.sample
+package=io.jenkins.plugins.sample

--- a/scripted-pipeline/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/scripted-pipeline/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -4,7 +4,7 @@
             <defaultValue>org.sample</defaultValue>
         </requiredProperty>
         <requiredProperty key="package">
-            <defaultValue>org.jenkinsci.pipeline.sample</defaultValue>
+            <defaultValue>io.jenkins.pipeline.sample</defaultValue>
         </requiredProperty>
     </requiredProperties>
     <fileSets>

--- a/scripted-pipeline/src/test/resources/projects/testInstall/archetype.properties
+++ b/scripted-pipeline/src/test/resources/projects/testInstall/archetype.properties
@@ -1,4 +1,4 @@
 groupId=org.sample
 artifactId=testArtifact
 version=1.0-SNAPSHOT
-package=org.jenkinsci.plugins.sample
+package=io.jenkins.plugins.sample


### PR DESCRIPTION
If nothing else, keeps people from trying to remember whether to use `jenkinsci`, `jenkins_ci`, `jenkinsCi`, etc.

@reviewbybees