### PR TITLE
Omitting redundant <description> in new plugin pom.xml since src/main/resources/index.jelly now suffices in all cases

### DIFF
--- a/empty-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/empty-plugin/src/main/resources/archetype-resources/pom.xml
@@ -16,7 +16,6 @@
         <java.level>7</java.level>
     </properties>
     <name>TODO Plugin</name>
-    <description>TODO</description>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/global-configuration/src/main/resources/archetype-resources/pom.xml
+++ b/global-configuration/src/main/resources/archetype-resources/pom.xml
@@ -16,7 +16,6 @@
         <java.level>8</java.level>
     </properties>
     <name>TODO Plugin</name>
-    <description>TODO</description>
     <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
     <licenses>
         <license>

--- a/hello-world/src/main/resources/archetype-resources/pom.xml
+++ b/hello-world/src/main/resources/archetype-resources/pom.xml
@@ -22,7 +22,6 @@
      -->
     </properties>
     <name>TODO Plugin</name>
-    <description>TODO</description>
     <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
     <licenses>
         <license>


### PR DESCRIPTION
Cleanup from https://github.com/jenkins-infra/update-center2/pull/204.