### PR TITLE
[JENKINS-58040] make note about mirror limitation in settings.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This has been deprecated in favor of the new archetypes, which cover more scenar
 
 The NetBeans IDE also offers a [plugin for Jenkins development](https://github.com/stapler/netbeans-stapler-plugin/blob/master/README.md) which offers a Jenkins plugin archetype via the **File » New Project** wizard.
 
-> If you have defined a mirror like this in your `settings.xml` you might NOT be able to use filter option as described above.
+If you have defined a mirror like this in your `settings.xml` you might _not_ be able to use filter option as described above.
 ```xml
 > <mirror>
 >   <id>repo.jenkins-ci.org-all</id>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ This has been deprecated in favor of the new archetypes, which cover more scenar
 
 The NetBeans IDE also offers a [plugin for Jenkins development](https://github.com/stapler/netbeans-stapler-plugin/blob/master/README.md) which offers a Jenkins plugin archetype via the **File » New Project** wizard.
 
+> If you have defined a mirror like this in your `settings.xml` you might NOT be able to use filter option as described above.
+> ```
+> <mirror>
+>   <id>repo.jenkins-ci.org-all</id>
+>   <url>https://repo.jenkins-ci.org/public</url>
+>   <mirrorOf>*</mirrorOf>
+> </mirror>```
+
 # Changes
 
 ## 1.4 (2018 Mar 12)

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ The NetBeans IDE also offers a [plugin for Jenkins development](https://github.c
 
 If you have defined a mirror like this in your `settings.xml` you might _not_ be able to use filter option as described above.
 ```xml
-> <mirror>
->   <id>repo.jenkins-ci.org-all</id>
->   <url>https://repo.jenkins-ci.org/public</url>
->   <mirrorOf>*</mirrorOf>
+ <mirror>
+   <id>repo.jenkins-ci.org-all</id>
+   <url>https://repo.jenkins-ci.org/public</url>
+   <mirrorOf>*</mirrorOf>
 </mirror>
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ This has been deprecated in favor of the new archetypes, which cover more scenar
 The NetBeans IDE also offers a [plugin for Jenkins development](https://github.com/stapler/netbeans-stapler-plugin/blob/master/README.md) which offers a Jenkins plugin archetype via the **File » New Project** wizard.
 
 > If you have defined a mirror like this in your `settings.xml` you might NOT be able to use filter option as described above.
-> ```
+```xml
 > <mirror>
 >   <id>repo.jenkins-ci.org-all</id>
 >   <url>https://repo.jenkins-ci.org/public</url>
 >   <mirrorOf>*</mirrorOf>
-> </mirror>```
+</mirror>
+```
 
 # Changes
 


### PR DESCRIPTION
[JENKINS-58040](https://issues.jenkins-ci.org/browse/JENKINS-58040) When using the following minimal maven `settings.xml`, no jenkinsci archetypes can be found

```xml
<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
  <localRepository/>
  <interactiveMode/>
  <usePluginRegistry/>
  <offline/>
  <pluginGroups/>
  <servers/>
  <mirrors>

		<mirror>
			<id>repo.jenkins-ci.org-all</id>
			<url>https://repo.jenkins-ci.org/public</url>
			<mirrorOf>*</mirrorOf>
		</mirror> 

  </mirrors>
  <proxies/>
  <profiles/>
  <activeProfiles/>
</settings>
```

```
platypus:mvn_test domi$ docker run -ti --rm -v "/tmp/dummy/settings.xml":/root/.m2/settings.xml --name mvn maven:3.6.1-jdk-8 mvn -ntp archetype:generate -Dfilter=io.jenkins.archetypes:
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------< org.apache.maven:standalone-pom >-------------------
[INFO] Building Maven Stub Project (No POM) 1
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] >>> maven-archetype-plugin:3.1.1:generate (default-cli) > generate-sources @ standalone-pom >>>
[INFO] 
[INFO] <<< maven-archetype-plugin:3.1.1:generate (default-cli) < generate-sources @ standalone-pom <<<
[INFO] 
[INFO] 
[INFO] --- maven-archetype-plugin:3.1.1:generate (default-cli) @ standalone-pom ---
[INFO] Generating project in Interactive mode
[INFO] Your filter doesn't match any archetype, so try again with another value.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  44.664 s
[INFO] Finished at: 2019-06-17T15:18:02Z
[INFO] ------------------------------------------------------------------------
```

As I don't have any workaround for this, I updated the `README.md` to inform users about it.

@jglick @jenkinsci/code-reviewers 

