### PR TITLE
Enable Dependabot for the repository

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,32 @@
+version: 1
+update_configs:
+- package_manager: "java:maven"
+  directory: "/"
+  update_schedule: "weekly"
+  default_reviewers:
+    - "jglick"
+- package_manager: "java:maven"
+  directory: "/empty-plugin/src/main/resources/archetype-resources"
+  update_schedule: "weekly"
+  default_reviewers:
+    - "jglick"
+- package_manager: "java:maven"
+  directory: "/hello-world/src/main/resources/archetype-resources"
+  update_schedule: "weekly"
+  default_reviewers:
+    - "jglick"
+- package_manager: "java:maven"
+  directory: "/global-configuration/src/main/resources/archetype-resources"
+  update_schedule: "weekly"
+  default_reviewers:
+    - "jglick"
+- package_manager: "java:maven"
+  directory: "/scripted-pipeline/src/main/resources/archetype-resources"
+  update_schedule: "weekly"
+  default_reviewers:
+    - "jglick"
+- package_manager: "java:maven"
+  directory: "/global-shared-library/src/main/resources/archetype-resources"
+  update_schedule: "weekly"
+  default_reviewers:
+    - "jglick"

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <module>global-configuration</module>
         <module>scripted-pipeline</module>
         <module>global-shared-library</module>
+        <!-- if adding new archetypes please also update .dependabot/config.yml -->
     </modules>
     <!-- These developers currently have write access to release to sonatype OSS -->
     <developers>


### PR DESCRIPTION
I requested access for Dependabot to this repo, but I am not an admin of it (only have write access); any way to find out who _is_ an admin?