### PR TITLE
Fix missing gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,5 +93,4 @@ docker run -ti --rm --name mvn --entrypoint /bin/bash maven:3.5.0-jdk-8
 
 * `HelloWorldBuilderTest` should use `BuildWatcher`
 * convert `ui-samples-plugin` to an archetype
-* `.gitignore` files do not get copied to actual archetype
 * add `Step` sample as per [this example](https://github.com/jglick/wfdev/blob/pipeline/src/main/java/demo/CountGreetingsStep.java)

--- a/empty-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/empty-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,5 +1,11 @@
 <archetype-descriptor xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd" name="empty Jenkins plugin">
     <fileSets>
+        <fileSet>
+            <directory/>
+            <includes>
+                <include>.gitignore</include>
+            </includes>
+        </fileSet>
         <fileSet filtered="true">
             <directory>.</directory>
             <includes>

--- a/global-configuration/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/global-configuration/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -8,6 +8,12 @@
         </requiredProperty>
     </requiredProperties>
     <fileSets>
+        <fileSet>
+            <directory/>
+            <includes>
+                <include>.gitignore</include>
+            </includes>
+        </fileSet>
         <fileSet filtered="true">
             <directory>.</directory>
             <includes>

--- a/global-shared-library/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/global-shared-library/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -21,6 +21,7 @@
             <directory></directory>
             <includes>
                 <include>README.md</include>
+                <include>.gitignore</include>
             </includes>
         </fileSet>
         <!-- Shared Library sources -->

--- a/hello-world/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/hello-world/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -8,6 +8,12 @@
         </requiredProperty>
     </requiredProperties>
     <fileSets>
+        <fileSet>
+            <directory/>
+            <includes>
+                <include>.gitignore</include>
+            </includes>
+        </fileSet>
         <fileSet filtered="true">
             <directory>.</directory>
             <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,22 @@
                         <tagNameFormat>archetypes-@{project.version}</tagNameFormat>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <configuration>
+                    <addDefaultExcludes>false</addDefaultExcludes>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
     <profiles>
         <profile> <!-- integration tests are a bit slow, no need to run them twice per release -->

--- a/scripted-pipeline/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/scripted-pipeline/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -17,6 +17,7 @@
         <fileSet>
             <directory></directory>
             <includes>
+                <include>.gitignore</include>
                 <include>Jenkinsfile</include>
             </includes>
         </fileSet>


### PR DESCRIPTION
ref: https://stackoverflow.com/a/46876927/4951015

To test:

```
mvn clean install -DskipTests # tests take awhile, generation is instant without

```

create a directory somewhere and enter it then:
```
mvn archetype:generate -B -DarchetypeGroupId=io.jenkins.archetypes -DarchetypeArtifactId=global-configuration-plugin -DarchetypeVersion=1.8-SNAPSHOT -DartifactId=cool-thing
```