### PR TITLE
Mistyped names of Incrementals profiles

### DIFF
--- a/common-files/.mvn/maven.config
+++ b/common-files/.mvn/maven.config
@@ -1,2 +1,2 @@
+-Pconsume-incrementals
 -Pmight-produce-incrementals
--Pmight-consume-incrementals


### PR DESCRIPTION
Amends #155. See https://github.com/jenkinsci/incrementals-tools/blob/f6fb2fd644fa0aa7be5c5173506d9368b542dd2d/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/IncrementalifyMojo.java#L99