### PR TITLE
Section on Contributing was specific to @jenkinsci

### DIFF
--- a/common-files/README.md
+++ b/common-files/README.md
@@ -25,7 +25,6 @@ TODO Decide where you're going to host your issues, the default is Jenkins JIRA,
 If you use GitHub issues there's no need for this section; else add the following line:
 
 Report issues and enhancements in the [Jenkins issue tracker](https://issues.jenkins-ci.org/).
-#end
 
 $H$H Contributing
 
@@ -33,7 +32,6 @@ TODO review the default [CONTRIBUTING](https://github.com/jenkinsci/.github/blob
 
 Refer to our [contribution guidelines](https://github.com/jenkinsci/.github/blob/master/CONTRIBUTING.md)
 
-#if( $hostOnJenkinsGitHub == "true" )
 $H$H LICENSE
 
 Licensed under MIT, see [LICENSE](LICENSE.md)


### PR DESCRIPTION
Amends #155. Does not really make sense for an in-house plugin, etc., and at a minimum they would not get access to the @jenkinsci defaults.