### PR TITLE
Set a defaultValue for hostOnJenkinsGitHub

### DIFF
--- a/empty-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/empty-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -34,6 +34,7 @@
         </requiredProperty>
         <requiredProperty key="hostOnJenkinsGitHub">
             <validationRegex>(true|false)</validationRegex>
+            <defaultValue>true</defaultValue>
         </requiredProperty>
     </requiredProperties>
 </archetype-descriptor>

--- a/global-configuration/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/global-configuration/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -13,6 +13,7 @@
         </requiredProperty>
         <requiredProperty key="hostOnJenkinsGitHub">
             <validationRegex>(true|false)</validationRegex>
+            <defaultValue>true</defaultValue>
         </requiredProperty>
     </requiredProperties>
     <fileSets>

--- a/hello-world/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/hello-world/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -13,6 +13,7 @@
         </requiredProperty>
         <requiredProperty key="hostOnJenkinsGitHub">
             <validationRegex>(true|false)</validationRegex>
+            <defaultValue>true</defaultValue>
         </requiredProperty>
     </requiredProperties>
     <fileSets>


### PR DESCRIPTION
Amending #155. Noticed because the NetBeans project wizard for Jenkins plugins broke. Does not work perfectly for reasons detailed in [ARCHETYPE-308](https://issues.apache.org/jira/browse/ARCHETYPE-308) (in particular, cannot simplify `*/src/test/resources/projects/testInstall/archetype.properties`), and also I stumbled across [ARCHETYPE-539](https://issues.apache.org/jira/browse/ARCHETYPE-539) which explains why it is so excruciatingly slow to test changes here.