### PR TITLE
Pin the version of Release Drafter, but include in Dependabot

### DIFF
--- a/common-files/.github/dependabot.yml
+++ b/common-files/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/common-files/.github/workflows/release-drafter.yml
+++ b/common-files/.github/workflows/release-drafter.yml
@@ -5,12 +5,13 @@ on:
   push:
     branches:
       - master
+      - main
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      # Drafts your next Release notes as Pull Requests are merged into the default branch
+      - uses: release-drafter/release-drafter@v5.13.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.com/release-drafter/release-drafter/pull/742 is significant.
