### PR TITLE
Use HTTPS protocol for all github.com SCM URLs

### DIFF
--- a/empty-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/empty-plugin/src/main/resources/archetype-resources/pom.xml
@@ -43,8 +43,8 @@
 
 
     #if( $hostOnJenkinsGitHub == "true" )<scm>
-        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
-        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <connection>scm:git:https://github.com/${gitHubRepo}</connection>
+        <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
     </scm>#end

--- a/global-configuration/src/main/resources/archetype-resources/pom.xml
+++ b/global-configuration/src/main/resources/archetype-resources/pom.xml
@@ -50,8 +50,8 @@
     </developers> -->
 
     #if( $hostOnJenkinsGitHub == "true" )<scm>
-        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
-        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <connection>scm:git:https://github.com/${gitHubRepo}</connection>
+        <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
     </scm>#end

--- a/hello-world/src/main/resources/archetype-resources/pom.xml
+++ b/hello-world/src/main/resources/archetype-resources/pom.xml
@@ -80,8 +80,8 @@
     </developers> -->
 
     #if( $hostOnJenkinsGitHub == "true" )<scm>
-        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
-        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <connection>scm:git:https://github.com/${gitHubRepo}</connection>
+        <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
     </scm>#end


### PR DESCRIPTION
Not to start a holy war or anything, but I think we should use HTTPS rather than SSH protocol for all `/project/scm`URLs. Currently we do so for `url` but use SSH for `developerConnection` and :warning: unencrypted anonymous Git protocol for `connection`. I suggest we normalize to HTTPS as the most generic, cross-platform, and contemporary protocol.

* https://stackoverflow.com/q/11041729/12916 is unclear
* https://gist.github.com/grawity/4392747 is pretty old (e.g. predates the fact that the `gh` CLI uses HTTPS)
* https://docs.github.com/en/github/using-git/which-remote-url-should-i-use is agnostic
* https://maven.apache.org/pom.html#SCM is spectacularly unhelpful (CVS?!)

Need to verify that `plugin-compat-tester` is not going to explode though. (That is basically the only consumer of the `<scm>` section. `incrementals-publisher` verifies its format.)
