### PR TITLE
Make shared-library/src avaiable in tests

### DIFF
--- a/global-shared-library/src/main/resources/archetype-resources/unit-tests/pom.xml
+++ b/global-shared-library/src/main/resources/archetype-resources/unit-tests/pom.xml
@@ -49,6 +49,9 @@
             <resource>
                 <directory>src/main/jenkins</directory>
             </resource>
+            <resource>
+                <directory>../shared-library/src</directory>
+            </resource>
         </resources>
         <testResources>
             <testResource>


### PR DESCRIPTION
Make shared-library/src avaiable in tests.

Test cases that are using classes from shared-library/src are working now if runned by 'mvn test'.

In regards of #331 