### PR TITLE
Replace `useAci` with `useContainerAgent`

### DIFF
--- a/common-files/Jenkinsfile
+++ b/common-files/Jenkinsfile
@@ -2,4 +2,4 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */
-buildPlugin(useAci: true)
+buildPlugin(useContainerAgent: true)


### PR DESCRIPTION
Avoid a deprecation: https://github.com/jenkins-infra/pipeline-library/pull/220
