### PR TITLE
Set `child.scm.*.inherit.append.path=false`

### DIFF
--- a/empty-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/empty-plugin/src/main/resources/archetype-resources/pom.xml
@@ -42,7 +42,7 @@
     </licenses>#end
 
 
-    #if( $hostOnJenkinsGitHub == "true" )<scm>
+    #if( $hostOnJenkinsGitHub == "true" )<scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
         <connection>scm:git:https://github.com/${gitHubRepo}</connection>
         <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>

--- a/global-configuration/src/main/resources/archetype-resources/pom.xml
+++ b/global-configuration/src/main/resources/archetype-resources/pom.xml
@@ -49,7 +49,7 @@
       </developer>
     </developers> -->
 
-    #if( $hostOnJenkinsGitHub == "true" )<scm>
+    #if( $hostOnJenkinsGitHub == "true" )<scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
         <connection>scm:git:https://github.com/${gitHubRepo}</connection>
         <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>

--- a/hello-world/src/main/resources/archetype-resources/pom.xml
+++ b/hello-world/src/main/resources/archetype-resources/pom.xml
@@ -79,7 +79,7 @@
       </developer>
     </developers> -->
 
-    #if( $hostOnJenkinsGitHub == "true" )<scm>
+    #if( $hostOnJenkinsGitHub == "true" )<scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
         <connection>scm:git:https://github.com/${gitHubRepo}</connection>
         <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <archetype.version>3.2.0</archetype.version>
     </properties>
-    <scm>
+    <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
         <connection>scm:git:git@github.com/jenkinsci/archetypes.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/archetypes.git</developerConnection>
         <url>https://github.com/jenkinsci/archetypes/</url>


### PR DESCRIPTION
Generalizing https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/465 to other plugins. Only relevant for repositories using `<modules>`, which none of these examples do, but so hard to track down when you need it that it seems best to just define it everywhere.
