### PR TITLE
Remove deprecated `java.level` property

### DIFF
--- a/empty-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/empty-plugin/src/main/resources/archetype-resources/pom.xml
@@ -31,7 +31,6 @@
         <revision>1.0</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.303.3</jenkins.version>
-        <java.level>8</java.level>
         #if( $hostOnJenkinsGitHub == "true" )<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>#end
     </properties>
 

--- a/global-configuration/src/main/resources/archetype-resources/pom.xml
+++ b/global-configuration/src/main/resources/archetype-resources/pom.xml
@@ -40,7 +40,6 @@
         <revision>1.0</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.303.3</jenkins.version>
-        <java.level>8</java.level>
         #if( $hostOnJenkinsGitHub == "true" )<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>#end
     </properties>
 

--- a/hello-world/src/main/resources/archetype-resources/pom.xml
+++ b/hello-world/src/main/resources/archetype-resources/pom.xml
@@ -42,7 +42,6 @@
 
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
         <jenkins.version>2.303.3</jenkins.version>
-        <java.level>8</java.level>
         #if( $hostOnJenkinsGitHub == "true" )<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>#end
     </properties>
 


### PR DESCRIPTION
Adapts to [4.40](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40).