### PR TITLE
Bump Maven from 3.8.1 to 3.8.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.1.1-experimental
-FROM maven:3.8.1-openjdk-11
+FROM maven:3.8.4
 COPY . /src
 WORKDIR /src
 RUN rm -rf .git


### PR DESCRIPTION
Also removing the `-openjdk-11` part so Dependabot can keep this up to date.