### PR TITLE
Pin release-drafter, bump git-changelist-maven-extension and fix dependabot URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ mvn -B release:{prepare,perform}
 
 In addition to needing write permission to this repository, you must have been preauthorized to deploy to the `io/jenkins/archetypes/` sector of OSSRH.
 
-Artifacts will [appear on Maven Central](http://repo1.maven.org/maven2/io/jenkins/archetypes/) after a few minutes.
+Artifacts will [appear on Maven Central](https://repo1.maven.org/maven2/io/jenkins/archetypes/) after a few minutes.
 But as noted in OSSRH-34275, the catalog only gets regenerated weekly; to check it:
 
 ```sh

--- a/common-files/.github/dependabot.yml
+++ b/common-files/.github/dependabot.yml
@@ -1,12 +1,12 @@
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
 
 version: 2
 updates:
 - package-ecosystem: maven
   directory: /
   schedule:
-    interval: monthly
+    interval: weekly
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    interval: monthly
+    interval: weekly

--- a/common-files/.github/dependabot.yml
+++ b/common-files/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
 - package-ecosystem: maven
   directory: /
   schedule:
-    interval: weekly
+    interval: monthly
 - package-ecosystem: github-actions
   directory: /
   schedule:

--- a/common-files/.github/dependabot.yml
+++ b/common-files/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    interval: weekly
+    interval: monthly

--- a/common-files/.github/workflows/release-drafter.yml
+++ b/common-files/.github/workflows/release-drafter.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into the default branch
-      - uses: release-drafter/release-drafter@v5.13.0
+      - uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/common-files/.mvn/extensions.xml
+++ b/common-files/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.2</version>
+    <version>1.4</version>
   </extension>
 </extensions>


### PR DESCRIPTION
This PR addresses a few common issues, I'm always highlighting when reviewing hosting requests.

Additionally, I replaced the dependabot help URL with a working one and reduced the runs from monthly to weekly. Given, a lot of plugins and components use JEP-229 nowadays, releases happen much more frequent, than on a monthly basis.