### PR TITLE
Expand test matrix by Java 11

### DIFF
--- a/common-files/Jenkinsfile
+++ b/common-files/Jenkinsfile
@@ -2,4 +2,4 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */
-buildPlugin(useContainerAgent: true)
+buildPlugin(useContainerAgent: true, platforms: ['linux', 'windows'], jdkVersions: [8, 11])


### PR DESCRIPTION
The hosting requirements have been updated to ensure a plugin's minimum baseline tooling supports Java 11 too, alongside Java 8.

I'd like to see Java 11 added to the default Jenkinsfile, to promote Java 11 tests even further. New plugins should be tested against our Java baseline version too, by default, rather than just Java 8.