### PR TITLE
fix(buildPlugin pipeline library) Correct instruction to use Docker containerized tests

### DIFF
--- a/common-files/Jenkinsfile
+++ b/common-files/Jenkinsfile
@@ -3,8 +3,8 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
-  useContainerAgent: true,
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 17], // use 'docker' if you have containerized tests
+    [platform: 'linux', jdk: 17],
     [platform: 'windows', jdk: 11],
 ])


### PR DESCRIPTION
The comment about 'docker' can be misleading. 

- The pipeline library abstracts away the logic around the concept of a "docker" platform
- Docker on containerized agent is not provided for security reasons (Docker in docker not allowed on ci.jenkins.io)
- Windows Docker works if needed
