### PR TITLE
Use proper path for dependabot common-files directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"
-    directory: "/common-files"
+    directory: "/common-files/.github/workflows"
     reviewers:
       - "jglick"
     schedule:


### PR DESCRIPTION
dependabot can't detect files outside the common directories, hence we need to use a direct path.