### PR TITLE
Add Jenkins security scan to common files

### DIFF
--- a/common-files/.github/workflows/jenkins-security-scan.yml
+++ b/common-files/.github/workflows/jenkins-security-scan.yml
@@ -19,5 +19,5 @@ jobs:
   security-scan:
     uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
-      java-cache: '' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
+      java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
       java-version: 11 # What version of Java to set up for the build.

--- a/common-files/.github/workflows/jenkins-security-scan.yml
+++ b/common-files/.github/workflows/jenkins-security-scan.yml
@@ -1,0 +1,23 @@
+# More information about the Jenkins security scan can be found at the developer docs: https://www.jenkins.io/doc/developer/security/scan/
+
+name: Jenkins Security Scan
+on:
+  push:
+    branches:
+      - "master"
+      - "main"
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  security-scan:
+    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
+    with:
+      java-cache: '' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
+      java-version: 11 # What version of Java to set up for the build.


### PR DESCRIPTION
New hosting requests are reviewed initially by our set of predefined CodeQL rules. The recent hosting requests subject to the new scanning showed long lists of issues (including a few false-positives).
Therefore, I'm assuming a lack of awareness of how to mitigate, and even better, avoid introducing possible security vulnerabilities in your plugin.

For this reasoning, I would like to include the security scan by default in all new plugins, to raise awareness of possible security issues and give maintainers an opportunity, to react to issues.