### PR TITLE
Improve formatting in `HelloWorldBuilderTest`

### DIFF
--- a/hello-world/src/main/resources/archetype-resources/src/test/java/HelloWorldBuilderTest.java
+++ b/hello-world/src/main/resources/archetype-resources/src/test/java/HelloWorldBuilderTest.java
@@ -66,7 +66,7 @@ public class HelloWorldBuilderTest {
         String agentLabel = "my-agent";
         jenkins.createOnlineSlave(Label.get(agentLabel));
         WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-scripted-pipeline");
-        String pipelineScript = "node {\n" + "  greet '" + name + "'\n" + "}";
+        String pipelineScript = "node {greet '" + name + "'}";
         job.setDefinition(new CpsFlowDefinition(pipelineScript, true));
         WorkflowRun completedBuild = jenkins.assertBuildStatusSuccess(job.scheduleBuild2(0));
         String expectedString = "Hello, " + name + "!";


### PR DESCRIPTION
Spotless reformatting (#619) defeated the purpose of the original manual formatting, which was to show the indentation of the Groovy script embedded in Java sources. This just seems to be impossible in Spotless, at least until we are on a new enough version of Java that we can use multiline string literals. (Some projects also use external `src/test/resources/**/*.groovy`, which has its own advantages of course, but forces readers and editors to flip back and forth between files for a single test case.)