### PR TITLE
Remove 'org.kohsuke:pom' as parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.kohsuke</groupId>
-        <artifactId>pom</artifactId>
-        <version>21</version>
-        <relativePath />
-    </parent>
     <groupId>io.jenkins.archetypes</groupId>
     <artifactId>archetypes-parent</artifactId>
     <version>1.20-SNAPSHOT</version>


### PR DESCRIPTION
This seems to be a left over and entirely unused nowadays, I was able to replay the Jenkinsfile fine locally, but pulls in [very dated](https://github.com/kohsuke/pom) dependencies, still.