### PR TITLE
apply a default initial `forkCount` of `1C` to new plugins to speedup the build.

### DIFF
--- a/common-files/Jenkinsfile
+++ b/common-files/Jenkinsfile
@@ -3,6 +3,7 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
+  forkCount: '0.45C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 21],

--- a/common-files/Jenkinsfile
+++ b/common-files/Jenkinsfile
@@ -3,7 +3,7 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
-  forkCount: '0.45C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 21],


### PR DESCRIPTION
apply a default initial `forkCount` of `1C` to new plugins to speedup the build.

The number has been chosen from a commonly used number in Jenkinsfils in use on several plugins in the community.

Some are of the opinion that the archetype offers the best practices (they do not exist) and changes to the pipeline should be reflected in all plugins (or the top 200).  I will not be suggesting these changes to any plugins, as the suggestion may be sub-optimal, rather the plugins maintainers should experiment themselves to find and set an optimal value.   Having said this - I still believe it makes sense to advertise (and set a default) for new plugins.


<!-- Please describe your pull request here. -->

### Testing done

`forkCount` has been used in several plugins already.  this exact Jenkinsfile has not been tested

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
