### PR TITLE
Bump baseline from 2.387.3 to 2.414.3

### DIFF
--- a/empty-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/empty-plugin/src/main/resources/archetype-resources/pom.xml
@@ -32,7 +32,7 @@
     <revision>1.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.414.3</jenkins.version>
     #if( $hostOnJenkinsGitHub == "true" )<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>#end
 
     <spotless.check.skip>false</spotless.check.skip>
@@ -42,8 +42,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <artifactId>bom-2.414.x</artifactId>
+        <version>2675.v1515e14da_7a_6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/global-configuration/src/main/resources/archetype-resources/pom.xml
+++ b/global-configuration/src/main/resources/archetype-resources/pom.xml
@@ -32,7 +32,7 @@
     <revision>1.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.414.3</jenkins.version>
     #if( $hostOnJenkinsGitHub == "true" )<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>#end
 
     <spotless.check.skip>false</spotless.check.skip>
@@ -42,8 +42,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <artifactId>bom-2.414.x</artifactId>
+        <version>2675.v1515e14da_7a_6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/hello-world/src/main/resources/archetype-resources/pom.xml
+++ b/hello-world/src/main/resources/archetype-resources/pom.xml
@@ -33,7 +33,7 @@
     <changelist>-SNAPSHOT</changelist>
 
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.414.3</jenkins.version>
     #if( $hostOnJenkinsGitHub == "true" )<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>#end
 
     <spotless.check.skip>false</spotless.check.skip>
@@ -44,8 +44,8 @@
       <dependency>
         <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <artifactId>bom-2.414.x</artifactId>
+        <version>2675.v1515e14da_7a_6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
2.387.3 is already gone from the recommended baseline pages, due to its age. I propose we move on to 2.414.3 because 2.401.3 will vanish next week too when we decide a new baseline.