### PR TITLE
Upgrade tests to use JUnit5

### DIFF
--- a/global-configuration/src/main/resources/archetype-resources/src/test/java/SampleConfigurationTest.java
+++ b/global-configuration/src/main/resources/archetype-resources/src/test/java/SampleConfigurationTest.java
@@ -1,11 +1,12 @@
-package io.jenkins.plugins.sample;
+package $package;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.File;
+import org.apache.commons.io.FileUtils;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlTextInput;
 import org.junit.jupiter.api.Test;
-import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
@@ -23,30 +24,45 @@ class SampleConfigurationTest {
      */
     @Test
     void uiAndStorage(JenkinsRule jenkins) throws Throwable {
-        jenkins.apply(
-                new Statement() {
-                    @Override
-                    public void evaluate() throws Throwable {
-                        assertNull(SampleConfiguration.get().getLabel(), "not set initially");
-                        HtmlForm config =
-                                jenkins.createWebClient().goTo("configure").getFormByName("config");
-                        HtmlTextInput textbox = config.getInputByName("_.label");
-                        textbox.setText("hello");
-                        jenkins.submit(config);
-                        assertEquals(
-                                "hello", SampleConfiguration.get().getLabel(), "global config page let us edit it");
-                    }
-                },
-                jenkins.getTestDescription());
+        assertNull(SampleConfiguration.get().getLabel(), "not set initially");
+        try (JenkinsRule.WebClient client = jenkins.createWebClient()) {
+            HtmlForm config = client.goTo("configure").getFormByName("config");
+            HtmlTextInput textbox = config.getInputByName("_.label");
+            textbox.setText("hello");
+            jenkins.submit(config);
+            assertEquals("hello", SampleConfiguration.get().getLabel(), "global config page let us edit it");
+        }
 
-        jenkins.apply(
-                new Statement() {
-                    @Override
-                    public void evaluate() throws Throwable {
-                        assertEquals(
-                                "hello", SampleConfiguration.get().getLabel(), "still there after restart of Jenkins");
-                    }
-                },
-                jenkins.getTestDescription());
+        jenkins = restartJenkins(jenkins);
+
+        assertEquals("hello", SampleConfiguration.get().getLabel(), "still there after restart of Jenkins");
+
+        FileUtils.deleteQuietly(jenkins.getInstance().getRootDir());
+    }
+
+    private static JenkinsRule restartJenkins(JenkinsRule currentJenkinsRule) throws Throwable {
+        // backup current instance
+        File backup = new File(currentJenkinsRule.getInstance().getRootDir() + "_" + System.currentTimeMillis());
+        FileUtils.copyDirectory(currentJenkinsRule.getInstance().getRootDir(), backup);
+
+        // shutdown and cleanup current instance
+        currentJenkinsRule.after();
+
+        // init new instance with previous port and home
+        JenkinsRule newJenkinsRule = new JenkinsRule() {
+            @Override
+            public void before() throws Throwable {
+                this.localPort = currentJenkinsRule.getURL().getPort();
+                this.testDescription = currentJenkinsRule.getTestDescription();
+                super.before();
+            }
+        }.withExistingHome(backup);
+
+        newJenkinsRule.before();
+
+        // delete backup
+        FileUtils.deleteQuietly(backup);
+
+        return newJenkinsRule;
     }
 }

--- a/hello-world/src/main/resources/archetype-resources/src/test/java/HelloWorldBuilderTest.java
+++ b/hello-world/src/main/resources/archetype-resources/src/test/java/HelloWorldBuilderTest.java
@@ -6,19 +6,17 @@ import hudson.model.Label;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class HelloWorldBuilderTest {
-
-    @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+@WithJenkins
+class HelloWorldBuilderTest {
 
     final String name = "Bobby";
 
     @Test
-    public void testConfigRoundtrip() throws Exception {
+    void testConfigRoundtrip(JenkinsRule jenkins) throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         project.getBuildersList().add(new HelloWorldBuilder(name));
         project = jenkins.configRoundtrip(project);
@@ -27,7 +25,7 @@ public class HelloWorldBuilderTest {
     }
 
     @Test
-    public void testConfigRoundtripFrench() throws Exception {
+    void testConfigRoundtripFrench(JenkinsRule jenkins) throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         HelloWorldBuilder builder = new HelloWorldBuilder(name);
         builder.setUseFrench(true);
@@ -40,7 +38,7 @@ public class HelloWorldBuilderTest {
     }
 
     @Test
-    public void testBuild() throws Exception {
+    void testBuild(JenkinsRule jenkins) throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         HelloWorldBuilder builder = new HelloWorldBuilder(name);
         project.getBuildersList().add(builder);
@@ -50,8 +48,7 @@ public class HelloWorldBuilderTest {
     }
 
     @Test
-    public void testBuildFrench() throws Exception {
-
+    void testBuildFrench(JenkinsRule jenkins) throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         HelloWorldBuilder builder = new HelloWorldBuilder(name);
         builder.setUseFrench(true);
@@ -62,7 +59,7 @@ public class HelloWorldBuilderTest {
     }
 
     @Test
-    public void testScriptedPipeline() throws Exception {
+    void testScriptedPipeline(JenkinsRule jenkins) throws Exception {
         String agentLabel = "my-agent";
         jenkins.createOnlineSlave(Label.get(agentLabel));
         WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-scripted-pipeline");


### PR DESCRIPTION
It should be considered best practice to start plugin development using JUnit5 over JUnit4. 

* `org.junit.*` imports being updated to JUnit5 equivalents
* Use `@WithJenkins` in combination with `JenkinsRule`
* Make test classes and methods package-private (convention for JUnit5)

I'm not 100% convinced that I migrated `SampleConfigurationTest` correctly since I was not able to find a proper equivalent for `JenkinsSessionRule` - maybe @basil could confirm if the test still covers the intended functionality.

### Testing done
Ran `mvn clean verify` without errors.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
