### PR TITLE
Fix generation of repos using  `-DhostOnJenkinsGitHub=false`

### DIFF
--- a/common-files/archetype-post-generate.groovy
+++ b/common-files/archetype-post-generate.groovy
@@ -16,10 +16,10 @@ if (properties.get("hostOnJenkinsGitHub") == "false") {
             '.github',
     ]
     filesToRemove.each {
-        new File(it, projectPath.toFile()).delete()
+        projectPath.resolve(it).toFile().delete()
     }
     directoriesToRemove.each {
-        new File(it, projectPath.toFile()).deleteDir()
+        projectPath.resolve(it).toFile().deleteDir()
     }
 }
 

--- a/empty-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/empty-plugin/src/main/resources/archetype-resources/pom.xml
@@ -15,28 +15,30 @@
   <packaging>hpi</packaging>
 
   <name>TODO Plugin</name>
-  #if( $hostOnJenkinsGitHub == "true" )<url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>#end
-
-  #if( $hostOnJenkinsGitHub == "true" )<licenses>
+#if( $hostOnJenkinsGitHub == "true" )
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+  <licenses>
     <license>
       <name>MIT License</name>
       <url>https://opensource.org/license/mit/</url>
     </license>
-  </licenses>#end
-
-  #if( $hostOnJenkinsGitHub == "true" )<scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+  </licenses>
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
     <connection>scm:git:https://github.com/${gitHubRepo}</connection>
     <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
     <tag>${scmTag}</tag>
     <url>https://github.com/${gitHubRepo}</url>
-  </scm>#end
+  </scm>
+#end
 
   <properties>
     <revision>1.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.version>2.414.3</jenkins.version>
-    #if( $hostOnJenkinsGitHub == "true" )<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>#end
+#if( $hostOnJenkinsGitHub == "true" )
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+#end
 
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/empty-plugin/src/test/resources/projects/testInstallNoGithub/archetype.properties
+++ b/empty-plugin/src/test/resources/projects/testInstallNoGithub/archetype.properties
@@ -1,0 +1,5 @@
+groupId=IGNORED
+artifactId=testArtifact
+version=1.0-SNAPSHOT
+package=IGNORED
+hostOnJenkinsGitHub=false

--- a/empty-plugin/src/test/resources/projects/testInstallNoGithub/goal.txt
+++ b/empty-plugin/src/test/resources/projects/testInstallNoGithub/goal.txt
@@ -1,0 +1,1 @@
+install -ntp

--- a/global-configuration/src/main/resources/archetype-resources/pom.xml
+++ b/global-configuration/src/main/resources/archetype-resources/pom.xml
@@ -15,28 +15,30 @@
   <packaging>hpi</packaging>
 
   <name>TODO Plugin</name>
-  #if( $hostOnJenkinsGitHub == "true" )<url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>#end
-
-  #if( $hostOnJenkinsGitHub == "true" )<licenses>
+#if( $hostOnJenkinsGitHub == "true" )
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+  <licenses>
     <license>
       <name>MIT License</name>
       <url>https://opensource.org/license/mit/</url>
     </license>
-  </licenses>#end
-
-  #if( $hostOnJenkinsGitHub == "true" )<scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+  </licenses>
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
     <connection>scm:git:https://github.com/${gitHubRepo}</connection>
     <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
     <tag>${scmTag}</tag>
     <url>https://github.com/${gitHubRepo}</url>
-  </scm>#end
+  </scm>
+#end
 
   <properties>
     <revision>1.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.version>2.414.3</jenkins.version>
-    #if( $hostOnJenkinsGitHub == "true" )<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>#end
+#if( $hostOnJenkinsGitHub == "true" )
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+#end
 
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/global-configuration/src/test/resources/projects/testInstallNoGithub/archetype.properties
+++ b/global-configuration/src/test/resources/projects/testInstallNoGithub/archetype.properties
@@ -1,0 +1,5 @@
+groupId=IGNORED
+artifactId=testArtifact
+version=1.0-SNAPSHOT
+package=io.jenkins.plugins.sample
+hostOnJenkinsGitHub=false

--- a/global-configuration/src/test/resources/projects/testInstallNoGithub/goal.txt
+++ b/global-configuration/src/test/resources/projects/testInstallNoGithub/goal.txt
@@ -1,0 +1,1 @@
+install -ntp

--- a/hello-world/src/main/resources/archetype-resources/pom.xml
+++ b/hello-world/src/main/resources/archetype-resources/pom.xml
@@ -15,21 +15,21 @@
   <packaging>hpi</packaging>
 
   <name>TODO Plugin</name>
-  #if( $hostOnJenkinsGitHub == "true" )<url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>#end
-
-  #if( $hostOnJenkinsGitHub == "true" )<licenses>
+#if( $hostOnJenkinsGitHub == "true" )
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+  <licenses>
     <license>
       <name>MIT License</name>
       <url>https://opensource.org/license/mit/</url>
     </license>
-  </licenses>#end
-
-  #if( $hostOnJenkinsGitHub == "true" )<scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+  </licenses>
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
     <connection>scm:git:https://github.com/${gitHubRepo}</connection>
     <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
     <tag>${scmTag}</tag>
     <url>https://github.com/${gitHubRepo}</url>
-  </scm>#end
+  </scm>
+#end
 
   <properties>
     <revision>1.0</revision>
@@ -37,7 +37,9 @@
 
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.version>2.414.3</jenkins.version>
-    #if( $hostOnJenkinsGitHub == "true" )<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>#end
+#if( $hostOnJenkinsGitHub == "true" )
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+#end
 
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/hello-world/src/test/resources/projects/testInstallNoGithub/archetype.properties
+++ b/hello-world/src/test/resources/projects/testInstallNoGithub/archetype.properties
@@ -1,0 +1,5 @@
+groupId=IGNORED
+artifactId=testArtifact
+version=1.0-SNAPSHOT
+package=io.jenkins.plugins.sample
+hostOnJenkinsGitHub=false

--- a/hello-world/src/test/resources/projects/testInstallNoGithub/goal.txt
+++ b/hello-world/src/test/resources/projects/testInstallNoGithub/goal.txt
@@ -1,0 +1,1 @@
+install -ntp


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixes #709 

The fix itself was trivial.

I added integration tests specifically for that scenario, but the tests broke with spotbugs errors (for the generated POM).  Example (snippet):
```
[INFO] [ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.43.0:check (default) on project testArtifact: The following files had format violations:
[INFO] [ERROR]     pom.xml
[INFO] [ERROR]         @@ -15,16 +15,14 @@
[INFO] [ERROR]          ··<packaging>hpi</packaging>
[INFO] [ERROR]          
[INFO] [ERROR]          ··<name>TODO·Plugin</name>
[INFO] [ERROR]         -··
[INFO] [ERROR]         -··
[INFO] [ERROR]         -··
[INFO] [ERROR]         +
[INFO] [ERROR]          ··<properties>
[INFO] [ERROR]          ····<revision>1.0</revision>
[INFO] [ERROR]          ····<changelist>-SNAPSHOT</changelist>
[INFO] [ERROR]          
[INFO] [ERROR]          ····<!--·https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/·-->
[INFO] [ERROR]          ····<jenkins.version>2.414.3</jenkins.version>
[INFO] [ERROR]         -····
[INFO] [ERROR]         +
[INFO] [ERROR]          ····<spotless.check.skip>false</spotless.check.skip>
[INFO] [ERROR]          ··</properties>
[INFO] [ERROR]          
[INFO] [ERROR] Run 'mvn spotless:apply' to fix these violations.
```

Obviously a plugin not hosted under the Jenkins umbrella would not be subject to these checks, so turning it off (only for `-DhostOnJenkinsGitHub=false`) might be considered a viable option, but it was not immediately obvious how to do so, so I explored how I could get the check to pass.

That led to my changing of the templates.  It appears that white-space handling [may be configurable](https://velocity.apache.org/engine/devel/developer-guide.html#space-gobbling) (thus allowing the templates to remain as-is), but changing the template was easier and I hoped more agreeable.  (Subjectively, I find it easier on the eyes as well.)

The key seemed to be having the directives at the beginning of the line.  That led to
```
#if ....
  <stuff>
#end
#if ...
  <stuff>
#end
#if ...
  <stuff>
#end
```
at which point I collapsed them into a single block.

I broke it into three commits to make it easy to:
1. take the fix only, if that's "good enough"
2. accept the additional tests, if you have a way to turn off the spotbugs check (in lieu of the template changes)

### Testing done
Executing the same invocation from #709, but with these fixes:
```sh
$ mvn -V archetype:generate -DarchetypeGroupId=io.jenkins.archetypes -DarchetypeArtifactId=empty-plugin -DhostOnJenkinsGitHub=false -DgroupId=mygroup -Dpackage=mypackage -DartifactId=myartifact -DinteractiveMode=false -DarchetypeCatalog=local
Apache Maven 3.9.2 (c9616018c7a021c1c39be70fb2843d6f5f9b8a1c)
Maven home: /opt/maven
Java version: 17.0.10, vendor: Private Build, runtime: /usr/lib/jvm/java-17-openjdk-amd64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.5.0-25-generic", arch: "amd64", family: "unix"
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------< org.apache.maven:standalone-pom >-------------------
[INFO] Building Maven Stub Project (No POM) 1
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] >>> archetype:3.2.1:generate (default-cli) > generate-sources @ standalone-pom >>>
[INFO] 
[INFO] <<< archetype:3.2.1:generate (default-cli) < generate-sources @ standalone-pom <<<
[INFO] 
[INFO] 
[INFO] --- archetype:3.2.1:generate (default-cli) @ standalone-pom ---
[INFO] Generating project in Batch mode
[INFO] Archetype [io.jenkins.archetypes:empty-plugin:1.25-SNAPSHOT] found in catalog local
[INFO] ----------------------------------------------------------------------------
[INFO] Using following parameters for creating project from Archetype: empty-plugin:1.25-SNAPSHOT
[INFO] ----------------------------------------------------------------------------
[INFO] Parameter: groupId, Value: mygroup
[INFO] Parameter: artifactId, Value: myartifact
[INFO] Parameter: version, Value: 1.0-SNAPSHOT
[INFO] Parameter: package, Value: mypackage
[INFO] Parameter: packageInPathFormat, Value: mypackage
[INFO] Parameter: package, Value: mypackage
[INFO] Parameter: hostOnJenkinsGitHub, Value: false
[INFO] Parameter: groupId, Value: mygroup
[INFO] Parameter: artifactId, Value: myartifact
[INFO] Parameter: version, Value: 1.0-SNAPSHOT
[WARNING] Don't override file /tmp/myartifact/
[INFO] Executing META-INF/archetype-post-generate.groovy post-generation script
Not hosting on Jenkins Github organisation, removing files specific to jenkinsci
[package:mypackage, hostOnJenkinsGitHub:false, groupId:mygroup, artifactId:myartifact, version:1.0-SNAPSHOT]
[INFO] Project created from Archetype in dir: /tmp/myartifact
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.838 s
[INFO] Finished at: 2024-03-14T22:23:34-06:00
[INFO] ------------------------------------------------------------------------
[WARNING] 
[WARNING] Plugin validation issues were detected in 2 plugin(s)
[WARNING] 
[WARNING]  * org.apache.maven.plugins:maven-site-plugin:3.12.1
[WARNING]  * org.apache.maven.plugins:maven-archetype-plugin:3.2.1
[WARNING] 
[WARNING] For more or less details, use 'maven.plugin.validation' property with one of the values (case insensitive): [BRIEF, DEFAULT, VERBOSE]
[WARNING]

$ ls -a myartifact/
.  ..  .gitignore  .mvn  pom.xml  README.md  src

$ grep -i github myartifact/pom.xml
<no output>
$
```

There are no maven failures, no `LICENSE.md`, no `Jenkinsfile`, no `.github/`, and a correctly named `.gitignore`.

The new integration tests validates the generated repo meets the same quality checks that a GitHub-hosted repo would, whatever that's worth.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
