### PR TITLE
Exclude parent pom 5.x from renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":semanticCommitsDisabled",
     "schedule:earlyMondays"
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,5 +12,13 @@
   "labels": [
     "dependencies"
   ],
+  "packageRules": [
+    {
+      "matchDepNames": [
+        "org.jenkins-ci.plugins:plugin"
+      ],
+      "allowedVersions": "< 5"
+    }
+  ],
   "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION
## Exclude parent pom 5.x from renovate updates

Projects configured from the archetype most often prefer to depend on the last release of a recent LTS line.  The archetype currently requires Jenkins 2.440.3 or newer.  When we switch to parent pom 5.x, we'll need to require Jenkins 2.475 (weekly) or Jenkins 2.479.x (LTS).

I think it will be several months before we're ready to switch the archetype to use plugin parent pom 5.x.  Until that time, this configures renovate to only recommend versions less than 5.x

### Testing done

Installed the renovate-config-validator locally with commands:

$ nvm install --lts
$ npx --yes --package renovate -- renovate-config-validator

Ran the configuration validator with

$ renovate-config-validator

Before this change, reported that migration was needed.  After this change, it no longer reports that migration is needed.

Does not check that the package name is correct, though I checked that with `git grep`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
