### PR TITLE
Upgrade tests to use JUnit5

### DIFF
--- a/global-configuration/src/main/resources/archetype-resources/pom.xml
+++ b/global-configuration/src/main/resources/archetype-resources/pom.xml
@@ -53,6 +53,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+    </dependencies>
   </dependencyManagement>
 
   <repositories>

--- a/global-configuration/src/main/resources/archetype-resources/pom.xml
+++ b/global-configuration/src/main/resources/archetype-resources/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.5</version>
     <relativePath />
   </parent>
 
@@ -35,8 +35,8 @@
     <revision>1.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
 #if( $hostOnJenkinsGitHub == "true" )
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 #end
@@ -49,11 +49,10 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3875.v1df09947cde6</version>
+        <version>3893.v213a_42768d35</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-    </dependencies>
   </dependencyManagement>
 
   <repositories>

--- a/global-configuration/src/main/resources/archetype-resources/src/test/java/SampleConfigurationTest.java
+++ b/global-configuration/src/main/resources/archetype-resources/src/test/java/SampleConfigurationTest.java
@@ -1,17 +1,15 @@
 package $package;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlTextInput;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsSessionRule;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class SampleConfigurationTest {
-
-    @Rule
-    public JenkinsSessionRule sessions = new JenkinsSessionRule();
+@WithJenkins
+class SampleConfigurationTest {
 
     /**
      * Tries to exercise enough code paths to catch common mistakes:
@@ -23,23 +21,18 @@ public class SampleConfigurationTest {
      * </ul>
      */
     @Test
-    public void uiAndStorage() throws Throwable {
-        sessions.then(r -> {
-            assertNull("not set initially", SampleConfiguration.get().getLabel());
-            HtmlForm config = r.createWebClient().goTo("configure").getFormByName("config");
+    void uiAndStorage(JenkinsRule jenkins) throws Throwable {
+        assertNull(SampleConfiguration.get().getLabel(), "not set initially");
+        try (JenkinsRule.WebClient client = jenkins.createWebClient()) {
+            HtmlForm config = client.goTo("configure").getFormByName("config");
             HtmlTextInput textbox = config.getInputByName("_.label");
             textbox.setText("hello");
-            r.submit(config);
-            assertEquals(
-                    "global config page let us edit it",
-                    "hello",
-                    SampleConfiguration.get().getLabel());
-        });
-        sessions.then(r -> {
-            assertEquals(
-                    "still there after restart of Jenkins",
-                    "hello",
-                    SampleConfiguration.get().getLabel());
-        });
+            jenkins.submit(config);
+            assertEquals("hello", SampleConfiguration.get().getLabel(), "global config page let us edit it");
+        }
+
+        jenkins.restart();
+
+        assertEquals("hello", SampleConfiguration.get().getLabel(), "still there after restart of Jenkins");
     }
 }

--- a/hello-world/src/main/resources/archetype-resources/src/test/java/HelloWorldBuilderTest.java
+++ b/hello-world/src/main/resources/archetype-resources/src/test/java/HelloWorldBuilderTest.java
@@ -6,19 +6,17 @@ import hudson.model.Label;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class HelloWorldBuilderTest {
-
-    @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+@WithJenkins
+class HelloWorldBuilderTest {
 
     final String name = "Bobby";
 
     @Test
-    public void testConfigRoundtrip() throws Exception {
+    void testConfigRoundtrip(JenkinsRule jenkins) throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         project.getBuildersList().add(new HelloWorldBuilder(name));
         project = jenkins.configRoundtrip(project);
@@ -27,7 +25,7 @@ public class HelloWorldBuilderTest {
     }
 
     @Test
-    public void testConfigRoundtripFrench() throws Exception {
+    void testConfigRoundtripFrench(JenkinsRule jenkins) throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         HelloWorldBuilder builder = new HelloWorldBuilder(name);
         builder.setUseFrench(true);
@@ -40,7 +38,7 @@ public class HelloWorldBuilderTest {
     }
 
     @Test
-    public void testBuild() throws Exception {
+    void testBuild(JenkinsRule jenkins) throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         HelloWorldBuilder builder = new HelloWorldBuilder(name);
         project.getBuildersList().add(builder);
@@ -50,8 +48,7 @@ public class HelloWorldBuilderTest {
     }
 
     @Test
-    public void testBuildFrench() throws Exception {
-
+    void testBuildFrench(JenkinsRule jenkins) throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         HelloWorldBuilder builder = new HelloWorldBuilder(name);
         builder.setUseFrench(true);
@@ -62,7 +59,7 @@ public class HelloWorldBuilderTest {
     }
 
     @Test
-    public void testScriptedPipeline() throws Exception {
+    void testScriptedPipeline(JenkinsRule jenkins) throws Exception {
         String agentLabel = "my-agent";
         jenkins.createOnlineSlave(Label.get(agentLabel));
         WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-scripted-pipeline");


### PR DESCRIPTION
Re-opened from https://github.com/jenkinsci/archetypes/pull/691

> It should be considered best practice to start plugin development using JUnit5 over JUnit4. 
> 
> * `org.junit.*` imports being updated to JUnit5 equivalents
> * Use `@WithJenkins` in combination with `JenkinsRule`
> * Make test classes and methods package-private (convention for JUnit5)
> 
> I'm not 100% convinced that I migrated `SampleConfigurationTest` correctly since I was not able to find a proper equivalent for `JenkinsSessionRule` - maybe @basil could confirm if the test still covers the intended functionality.

Now that https://github.com/jenkinsci/jenkins-test-harness/pull/716 was merged there is a clean way to implement `SampleConfigurationTest.java` with JUnit5.

Creating this as a draft, since it depends on `plugin pom` after `5.5`, which required to bump the `jenkins.baseline` to `2.479.x`. Any feedback is highly welcome.

### Testing done
Ran `mvn clean verify` without errors.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
