### PR TITLE
Remove ban on renovate updates for 5.x pom

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,13 +12,5 @@
   "labels": [
     "dependencies"
   ],
-  "packageRules": [
-    {
-      "matchDepNames": [
-        "org.jenkins-ci.plugins:plugin"
-      ],
-      "allowedVersions": "< 5"
-    }
-  ],
   "rebaseWhen": "conflicted"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -38,15 +38,6 @@
             </roles>
         </developer>
         <developer>
-            <id>christ66</id>
-            <name>Steven Christou</name>
-            <email>schristou88@gmail.com</email>
-            <roles>
-                <role>release</role>
-                <role>maintainer</role>
-            </roles>
-        </developer>
-        <developer>
             <id>NotMyFault</id>
             <name>Alexander Brandes</name>
             <email>contact(at)notmyfault.dev</email>


### PR DESCRIPTION
Reverts https://github.com/jenkinsci/archetypes/pull/763, because 2.479 is now being used as baseline in the different archetypes.