### PR TITLE
Add base tests to themes

### DIFF
--- a/common-files/archetype-post-generate.groovy
+++ b/common-files/archetype-post-generate.groovy
@@ -1,7 +1,6 @@
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.stream.Stream
 
 Path projectPath = Paths.get(request.outputDirectory, request.artifactId)
 Properties properties = request.properties
@@ -25,28 +24,27 @@ if (properties.get("hostOnJenkinsGitHub") == "false") {
 }
 
 properties.get('theme')?.with { theme ->
+    def packagePath = (properties.get('package') as String).replace('.', File.separator)
+    def main = projectPath.resolve('src').resolve('main')
+    def mainJava = main.resolve('java').resolve(packagePath)
+    def testJava = projectPath.resolve('src').resolve('test').resolve('java').resolve(packagePath)
+
     def parts = (theme as String).split('-').collect { it.capitalize() }
     def themeClassName = parts.join('')
-    def themeTitleName = parts.join(' ')
-    def themeConstantName = parts.collect {it.toUpperCase()}.join('_')
-
     def replacements = [
             new TextReplacement('$THEME_CLASS_NAME', themeClassName),
-            new TextReplacement('$THEME_TITLE_NAME', themeTitleName),
-            new TextReplacement('$THEME_CONSTANT_NAME', themeConstantName)
+            new TextReplacement('$THEME_TITLE_NAME', parts.join(' ')),
+            new TextReplacement('$THEME_CONSTANT_NAME', parts.collect { it.toUpperCase() }.join('_'))
     ]
 
-    replaceInFile(projectPath, [
-            new FileReplacement('__themeClassNameRootAction.java', "${themeClassName}RootAction.java", replacements),
-            new FileReplacement('__themeClassNameTheme.java', "${themeClassName}Theme.java", replacements),
-            new FileReplacement('__themeClassNameThemeTest.java', "${themeClassName}ThemeTest.java", replacements),
-            new FileReplacement('index.jelly', null, replacements),
-            new FileReplacement('Theme.java', null, replacements),
-            new FileReplacement('pom.xml', null, replacements),
-            new FileReplacement('README.md', null, replacements)
-    ])
+    replace(mainJava.resolve('__themeClassNameRootAction.java'), replacements, "${themeClassName}RootAction.java")
+    replace(mainJava.resolve('__themeClassNameTheme.java'), replacements, "${themeClassName}Theme.java")
+    replace(main.resolve('resources').resolve('index.jelly'), replacements)
+    replace(testJava.resolve('playwright').resolve('__themeClassNameThemeTest.java'), replacements, "${themeClassName}ThemeTest.java")
+    replace(testJava.resolve('playwright').resolve('Theme.java'), replacements)
+    replace(projectPath.resolve('pom.xml'), replacements)
+    replace(projectPath.resolve('README.md'), replacements)
 }
-
 
 // Adding gitignore file via maven-resources-plugin is broken
 // see https://issues.apache.org/jira/browse/ARCHETYPE-505?focusedCommentId=17277974&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17277974
@@ -61,18 +59,8 @@ record TextReplacement(String target, String replacement) {
     String replace(String content) { content.replace(target, replacement) }
 }
 
-record FileReplacement(String oldName, String newName, List<TextReplacement> replacements) {
-    boolean matches(Path path) { oldName == path.getFileName().toString() }
-
-    void replace(Path path) {
-        def file = path.toFile()
-        file.text = replacements.inject(file.text as String) { acc, r -> r.replace(acc) }
-        newName?.with { Files.move(path, path.parent.resolve(it)) }
-    }
-}
-
-private static void replaceInFile(Path projectPath, List<FileReplacement> files) {
-    try (Stream<Path> pathStream = Files.find(projectPath, Integer.MAX_VALUE, (path, _) -> files.any { it.matches(path) })) {
-        pathStream.forEach { it -> files.find {r -> r.matches(it) }.replace(it) }
-    }
+private static void replace(Path target, List<TextReplacement> replacements, String newName = null) {
+    def file = target.toFile()
+    file.text = replacements.inject(file.text as String) { acc, r -> r.replace(acc) }
+    newName?.with { Files.move(target, target.parent.resolve(it)) }
 }

--- a/common-files/archetype-post-generate.groovy
+++ b/common-files/archetype-post-generate.groovy
@@ -25,11 +25,11 @@ if (properties.get("hostOnJenkinsGitHub") == "false") {
 }
 
 properties.get('theme')?.with { theme ->
-    String[] parts = theme.split("-").collect { it.capitalize() }
-    String themeClassName = parts.join('')
-    String themeTitleName = parts.join(' ')
+    def parts = (theme as String).split('-').collect { it.capitalize() }
+    def themeClassName = parts.join('')
+    def themeTitleName = parts.join(' ')
 
-    List<TextReplacement> replacements = [
+    def replacements = [
             new TextReplacement('$THEME_CLASS_NAME', themeClassName),
             new TextReplacement('$THEME_TITLE_NAME', themeTitleName)
     ]
@@ -62,7 +62,7 @@ record FileReplacement(String oldName, String newName, List<TextReplacement> rep
     boolean matches(Path path) { oldName == path.getFileName().toString() }
 
     void replace(Path path) {
-        File file = path.toFile()
+        def file = path.toFile()
         file.text = replacements.inject(file.text as String) { acc, r -> r.replace(acc) }
         newName?.with { Files.move(path, path.parent.resolve(it)) }
     }

--- a/common-files/archetype-post-generate.groovy
+++ b/common-files/archetype-post-generate.groovy
@@ -28,10 +28,12 @@ properties.get('theme')?.with { theme ->
     def parts = (theme as String).split('-').collect { it.capitalize() }
     def themeClassName = parts.join('')
     def themeTitleName = parts.join(' ')
+    def themeConstantName = parts.collect {it.toUpperCase()}.join('_')
 
     def replacements = [
             new TextReplacement('$THEME_CLASS_NAME', themeClassName),
-            new TextReplacement('$THEME_TITLE_NAME', themeTitleName)
+            new TextReplacement('$THEME_TITLE_NAME', themeTitleName),
+            new TextReplacement('$THEME_CONSTANT_NAME', themeConstantName)
     ]
 
     replaceInFile(projectPath, [
@@ -39,6 +41,7 @@ properties.get('theme')?.with { theme ->
             new FileReplacement('__themeClassNameTheme.java', "${themeClassName}Theme.java", replacements),
             new FileReplacement('__themeClassNameThemeTest.java', "${themeClassName}ThemeTest.java", replacements),
             new FileReplacement('index.jelly', null, replacements),
+            new FileReplacement('Theme.java', null, replacements),
             new FileReplacement('pom.xml', null, replacements),
             new FileReplacement('README.md', null, replacements)
     ])

--- a/common-files/archetype-post-generate.groovy
+++ b/common-files/archetype-post-generate.groovy
@@ -42,6 +42,7 @@ properties.get('theme')?.with { theme ->
     replace(main.resolve('resources').resolve('index.jelly'), replacements)
     replace(testJava.resolve('playwright').resolve('__themeClassNameThemeTest.java'), replacements, "${themeClassName}ThemeTest.java")
     replace(testJava.resolve('playwright').resolve('Theme.java'), replacements)
+    replace(testJava.resolve('jcasc').resolve('__themeClassNameThemeJCasCTest.java'), replacements, "${themeClassName}ThemeJCasCTest.java")
     replace(projectPath.resolve('pom.xml'), replacements)
     replace(projectPath.resolve('README.md'), replacements)
 }

--- a/theme-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/theme-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -47,6 +47,9 @@
     <fileSet filtered="true">
       <directory>src/main/resources</directory>
     </fileSet>
+    <fileSet filtered="true" packaged="true">
+      <directory>src/test/resources</directory>
+    </fileSet>
     <fileSet filtered="true">
       <directory>src/main/webapp</directory>
     </fileSet>

--- a/theme-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/theme-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -36,23 +36,19 @@
       <excludes>
         <exclude>src/**</exclude>
         <exclude>pom.xml</exclude>
-        <exclude>README.md</exclude>
       </excludes>
     </fileSet>
     <fileSet filtered="true" packaged="true">
       <directory>src/main/java</directory>
+    </fileSet>
+    <fileSet filtered="true" packaged="true">
+      <directory>src/test/java</directory>
     </fileSet>
     <fileSet filtered="true">
       <directory>src/main/resources</directory>
     </fileSet>
     <fileSet filtered="true">
       <directory>src/main/webapp</directory>
-    </fileSet>
-    <fileSet filtered="true">
-      <directory/>
-      <includes>
-        <include>README.md</include>
-      </includes>
     </fileSet>
   </fileSets>
 </archetype-descriptor>

--- a/theme-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/theme-plugin/src/main/resources/archetype-resources/pom.xml
@@ -58,6 +58,13 @@
       <artifactId>theme-manager</artifactId>
       <version>313.v8657a_a_7692cb_</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>playwright</artifactId>
+      <version>1.52.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/theme-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/theme-plugin/src/main/resources/archetype-resources/pom.xml
@@ -65,6 +65,16 @@
       <version>1.52.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/java/__themeClassNameThemeTest.java
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/java/__themeClassNameThemeTest.java
@@ -1,0 +1,26 @@
+package ${package};
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.junit.UsePlaywright;
+import ${package}.playwright.AppearancePage;
+import ${package}.playwright.PlaywrightConfig;
+import ${package}.playwright.Theme;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+@UsePlaywright(PlaywrightConfig.class)
+public class $THEME_CLASS_NAMEThemeTest {
+
+  @Test
+  void themeLoads(JenkinsRule j, Page p) {
+    Theme theme = Theme.of(new $THEME_CLASS_NAMETheme.DescriptorImpl(), Theme.CssVariable.background("white"));
+    new AppearancePage(p, j.jenkins.getRootUrl())
+        .goTo()
+        .themeIsPresent(theme)
+        .selectTheme(theme)
+        .themeIsApplied(theme);
+  }
+}

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/java/jcasc/AbstractThemeJCasCTest.java
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/java/jcasc/AbstractThemeJCasCTest.java
@@ -1,0 +1,61 @@
+package ${package}.jcasc;
+
+import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
+import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import hudson.ExtensionList;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.thememanager.ThemeManagerFactory;
+import io.jenkins.plugins.thememanager.ThemeManagerPageDecorator;
+import java.util.Objects;
+import jenkins.appearance.AppearanceCategory;
+import jenkins.model.GlobalConfigurationCategory;
+import org.junit.jupiter.api.Test;
+
+@WithJenkinsConfiguredWithCode
+public abstract class AbstractThemeJCasCTest {
+
+  protected abstract Class<? extends ThemeManagerFactory> getThemeManagerFactory();
+
+  @Test
+  @ConfiguredWithCode("ConfigurationAsCode.yml")
+  void testConfig(JenkinsConfiguredWithCodeRule j) {
+    ThemeManagerPageDecorator decorator = ThemeManagerPageDecorator.get();
+
+    ThemeManagerFactory theme = decorator.getTheme();
+    assertNotNull(theme);
+    assertThat(decorator.isDisableUserThemes(), is(true));
+    assertThat(theme, instanceOf(getThemeManagerFactory()));
+  }
+
+  @Test
+  @ConfiguredWithCode("ConfigurationAsCode.yml")
+  void testExport(JenkinsConfiguredWithCodeRule j) throws Exception {
+    ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+    CNode themeManager = getAppearanceRoot(context).get("themeManager");
+
+    String exported = toYamlString(themeManager);
+    String expected = toStringFromYamlFile(this, "ConfigurationAsCodeExport.yml");
+
+    assertThat(exported, is(expected));
+  }
+
+  private static Mapping getAppearanceRoot(ConfigurationContext context) {
+    GlobalConfigurationCategory category =
+        ExtensionList.lookup(AppearanceCategory.class).get(0);
+    GlobalConfigurationCategoryConfigurator configurator = new GlobalConfigurationCategoryConfigurator(category);
+    GlobalConfigurationCategory target = configurator.getTargetComponent(context);
+    return Objects.requireNonNull(configurator.describe(target, context)).asMapping();
+  }
+}

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/java/jcasc/__themeClassNameThemeJCasCTest.java
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/java/jcasc/__themeClassNameThemeJCasCTest.java
@@ -1,0 +1,14 @@
+package ${package}.jcasc;
+
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import ${package}.$THEME_CLASS_NAMETheme;
+import io.jenkins.plugins.thememanager.ThemeManagerFactory;
+
+@WithJenkinsConfiguredWithCode
+class $THEME_CLASS_NAMEThemeJCasCTest extends AbstractThemeJCasCTest {
+
+    @Override
+    protected Class<? extends ThemeManagerFactory> getThemeManagerFactory() {
+        return $THEME_CLASS_NAMETheme.class;
+    }
+}

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/AppearancePage.java
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/AppearancePage.java
@@ -1,0 +1,90 @@
+package ${package}.playwright;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Page.GetByRoleOptions;
+import com.microsoft.playwright.TimeoutError;
+import com.microsoft.playwright.options.AriaRole;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AppearancePage extends JenkinsPage<AppearancePage> {
+
+    private static final Logger log = LoggerFactory.getLogger(AppearancePage.class);
+
+    public AppearancePage(Page page, String rootUrl) {
+        super(page, rootUrl + "/manage/appearance/");
+    }
+
+    public AppearancePage themeIsPresent(Theme theme) {
+        log.info("Checking if theme '{}' is present", theme);
+        Locator themeBox = getThemeBox(theme);
+        assertThat(themeBox).isVisible();
+        checkAppearance(
+                ".app-theme-picker__picker[data-theme='" + theme.id() + "'] > svg > g > rect:nth-child(1)",
+                theme.variableToCheck());
+        return this;
+    }
+
+    public AppearancePage selectTheme(Theme theme) {
+        log.info("Selecting theme '{}'", theme.name());
+        getThemeBox(theme).click();
+        return this;
+    }
+
+    public AppearancePage themeIsApplied(Theme theme) {
+        log.info("Checking if theme '{}' is applied", theme);
+        assertThat(page.locator("html")).hasAttribute("data-theme", theme.id());
+        assertThat(getThemeBox(theme).getByRole(AriaRole.RADIO)).isChecked();
+        checkAppearance("body", theme.variableToCheck());
+        return this;
+    }
+
+    /**
+     * Locates the theme box for the given theme.
+     *
+     * @param theme the theme to locate
+     * @return the locator for the theme box
+     */
+    private Locator getThemeBox(Theme theme) {
+        log.debug("Locating theme box for '{}'", theme);
+        return page.getByRole(AriaRole.RADIO, new GetByRoleOptions().setName(theme.name()))
+                .locator("..");
+    }
+
+    /**
+     * Checks the appearance of an element based on a CSS variable.
+     *
+     * @param selector the CSS selector of the element to check
+     * @param variable the CSS variable to check against
+     */
+    private void checkAppearance(String selector, Theme.CssVariable variable) {
+        log.debug("Checking appearance for selector '{}' with CSS variable '{}'", selector, variable);
+        try {
+            page.waitForFunction(
+                """
+        ([selector, cssVar, expected]) => {
+          const el = document.querySelector(selector);
+          if (!el) return false;
+          return getComputedStyle(el).getPropertyValue(cssVar).trim() === expected;
+        }""",
+                List.of(selector, variable.name(), variable.expected()));
+        } catch (TimeoutError e) {
+            Object value = page.evaluate(
+                """
+                ([selector, cssVar]) => {
+                  const el = document.querySelector(selector);
+                  if (!el) return null;
+                  return getComputedStyle(el).getPropertyValue(cssVar).trim();
+                }""",
+                List.of(selector, variable.name()));
+            throw new AssertionError(
+                "Could not verify that '%s' was equal to '%s', found '%s'"
+                    .formatted(variable.name(), variable.expected(), value),
+                e);
+        }
+    }
+}

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/AppearancePage.java
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/AppearancePage.java
@@ -21,38 +21,29 @@ public class AppearancePage extends JenkinsPage<AppearancePage> {
 
     public AppearancePage themeIsPresent(Theme theme) {
         log.info("Checking if theme '{}' is present", theme);
-        Locator themeBox = getThemeBox(theme);
-        assertThat(themeBox).isVisible();
-        checkAppearance(
-                ".app-theme-picker__picker[data-theme='" + theme.id() + "'] > svg > g > rect:nth-child(1)",
-                theme.variableToCheck());
+        assertThat(getThemeCard(theme)).isVisible();
+        checkAppearance(".app-theme-picker__picker[data-theme='" + theme.id() + "']", theme.variableToCheck());
         return this;
     }
 
     public AppearancePage selectTheme(Theme theme) {
         log.info("Selecting theme '{}'", theme.name());
-        getThemeBox(theme).click();
+        getThemeCard(theme).click();
         return this;
     }
 
     public AppearancePage themeIsApplied(Theme theme) {
         log.info("Checking if theme '{}' is applied", theme);
+        assertThat(getThemeCard(theme).getByRole(AriaRole.RADIO)).isChecked();
         assertThat(page.locator("html")).hasAttribute("data-theme", theme.id());
-        assertThat(getThemeBox(theme).getByRole(AriaRole.RADIO)).isChecked();
         checkAppearance("body", theme.variableToCheck());
         return this;
     }
 
-    /**
-     * Locates the theme box for the given theme.
-     *
-     * @param theme the theme to locate
-     * @return the locator for the theme box
-     */
-    private Locator getThemeBox(Theme theme) {
+    private Locator getThemeCard(Theme theme) {
         log.debug("Locating theme box for '{}'", theme);
         return page.getByRole(AriaRole.RADIO, new GetByRoleOptions().setName(theme.name()))
-                .locator("..");
+            .locator("..");
     }
 
     /**

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/JenkinsPage.java
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/JenkinsPage.java
@@ -1,0 +1,40 @@
+package ${package}.playwright;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.TimeoutError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+abstract class JenkinsPage<T extends JenkinsPage<T>> {
+
+    private static final Logger log = LoggerFactory.getLogger(JenkinsPage.class);
+    protected final String pageUrl;
+    protected final Page page;
+
+    protected JenkinsPage(Page page, String pageUrl) {
+        this.page = page;
+        this.pageUrl = pageUrl;
+    }
+
+    @SuppressWarnings("unchecked")
+    T waitForLoaded() {
+        isAtUrl(pageUrl);
+        return (T) this;
+    }
+
+    public T goTo() {
+        log.info("Navigating to {}", pageUrl);
+        page.navigate(pageUrl);
+        return waitForLoaded();
+    }
+
+    void isAtUrl(String url) {
+        log.info("Waiting for url to be {}", url);
+        try {
+            page.waitForURL(url);
+        } catch (TimeoutError e) {
+            throw new TimeoutError(
+                    "Timeout exceeding waiting for the url to be " + url + " but it was " + page.url(), e);
+        }
+    }
+}

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/PlaywrightConfig.java
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/PlaywrightConfig.java
@@ -1,0 +1,18 @@
+package ${package}.playwright;
+
+import com.microsoft.playwright.junit.Options;
+import com.microsoft.playwright.junit.OptionsFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PlaywrightConfig implements OptionsFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(PlaywrightConfig.class);
+
+    @Override
+    public Options getOptions() {
+        boolean headless = Boolean.parseBoolean(System.getProperty("playwright.headless", "true"));
+        log.info("Running Playwright in {} mode", headless ? "headless" : "headed");
+        return new Options().setBrowserName("chromium").setHeadless(headless);
+    }
+}

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/Theme.java
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/Theme.java
@@ -1,0 +1,49 @@
+package ${package}.playwright;
+
+import io.jenkins.plugins.thememanager.ThemeManagerFactoryDescriptor;
+
+public record Theme(String name, String id, CssVariable variableToCheck) {
+    public Theme {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("Theme name cannot be null or empty");
+        }
+        if (id == null || id.isEmpty()) {
+            throw new IllegalArgumentException("Theme id cannot be null or empty");
+        }
+        if (variableToCheck == null) {
+            throw new IllegalArgumentException("Variable to check cannot be null");
+        }
+    }
+
+    public static Theme of(ThemeManagerFactoryDescriptor theme, CssVariable variableToCheck) {
+        return new Theme(theme.getDisplayName(), theme.getThemeKey(), variableToCheck);
+    }
+
+    public record CssVariable(String name, String expected) {
+
+        public CssVariable {
+            if (name == null || name.isEmpty()) {
+                throw new IllegalArgumentException("CSS variable name cannot be null or empty");
+            }
+            if (!name.startsWith("--")) {
+                throw new IllegalArgumentException("CSS variable name must start with '--'");
+            }
+            if (expected == null || expected.isEmpty()) {
+                throw new IllegalArgumentException("Expected value cannot be null or empty");
+            }
+        }
+
+        public static CssVariable background(String expectedValue) {
+            return new CssVariable("--background", expectedValue);
+        }
+
+        public String name() {
+            return name;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/Theme.java
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/Theme.java
@@ -1,8 +1,14 @@
 package ${package}.playwright;
 
+import static ${package}.playwright.Theme.CssVariable.background;
+
+import ${package}.$THEME_CLASS_NAMETheme;
 import io.jenkins.plugins.thememanager.ThemeManagerFactoryDescriptor;
 
 public record Theme(String name, String id, CssVariable variableToCheck) {
+
+    public static Theme $THEME_CONSTANT_NAME = new Theme(new $THEME_CLASS_NAMETheme.DescriptorImpl(), background("white"));
+
     public Theme {
         if (name == null || name.isEmpty()) {
             throw new IllegalArgumentException("Theme name cannot be null or empty");
@@ -15,12 +21,11 @@ public record Theme(String name, String id, CssVariable variableToCheck) {
         }
     }
 
-    public static Theme of(ThemeManagerFactoryDescriptor theme, CssVariable variableToCheck) {
-        return new Theme(theme.getDisplayName(), theme.getThemeKey(), variableToCheck);
+    public Theme(ThemeManagerFactoryDescriptor theme, CssVariable variableToCheck) {
+        this(theme.getDisplayName(), theme.getThemeKey(), variableToCheck);
     }
 
     public record CssVariable(String name, String expected) {
-
         public CssVariable {
             if (name == null || name.isEmpty()) {
                 throw new IllegalArgumentException("CSS variable name cannot be null or empty");
@@ -35,10 +40,6 @@ public record Theme(String name, String id, CssVariable variableToCheck) {
 
         public static CssVariable background(String expectedValue) {
             return new CssVariable("--background", expectedValue);
-        }
-
-        public String name() {
-            return name;
         }
     }
 

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/__themeClassNameThemeTest.java
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/__themeClassNameThemeTest.java
@@ -1,11 +1,7 @@
-package ${package};
+package ${package}.playwright;
 
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.junit.UsePlaywright;
-import ${package}.playwright.AppearancePage;
-import ${package}.playwright.PlaywrightConfig;
-import ${package}.playwright.Theme;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
@@ -16,7 +12,7 @@ public class $THEME_CLASS_NAMEThemeTest {
 
   @Test
   void themeLoads(JenkinsRule j, Page p) {
-    Theme theme = Theme.of(new $THEME_CLASS_NAMETheme.DescriptorImpl(), Theme.CssVariable.background("white"));
+    Theme theme = Theme.$THEME_CONSTANT_NAME;
     new AppearancePage(p, j.jenkins.getRootUrl())
         .goTo()
         .themeIsPresent(theme)

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/resources/jcasc/ConfigurationAsCode.yml
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/resources/jcasc/ConfigurationAsCode.yml
@@ -1,0 +1,5 @@
+---
+appearance:
+  themeManager:
+    disableUserThemes: true
+    theme: "${theme}"

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/resources/jcasc/ConfigurationAsCodeExport.yml
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/resources/jcasc/ConfigurationAsCodeExport.yml
@@ -1,0 +1,2 @@
+disableUserThemes: true
+theme: "${theme}"


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Based on the work done in https://github.com/jenkinsci/catppuccin-theme-plugin/pull/3 and https://github.com/jenkinsci/catppuccin-theme-plugin/pull/4 I'm updating the archetype to include these tests by default so that developers can have example implementations on how to write the tests out of the box.

### Testing done

`mvn clean verify -rf :theme-plugin`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
