### PR TITLE
Remove usages of Commons Lang from example plugin

### DIFF
--- a/global-configuration/src/main/resources/archetype-resources/src/main/java/SampleConfiguration.java
+++ b/global-configuration/src/main/resources/archetype-resources/src/main/java/SampleConfiguration.java
@@ -4,7 +4,6 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.util.FormValidation;
 import jenkins.model.GlobalConfiguration;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -42,7 +41,7 @@ public class SampleConfiguration extends GlobalConfiguration {
     }
 
     public FormValidation doCheckLabel(@QueryParameter String value) {
-        if (StringUtils.isEmpty(value)) {
+        if (value == null || value.isEmpty()) {
             return FormValidation.warning("Please specify a label.");
         }
         return FormValidation.ok();


### PR DESCRIPTION
Simpler and more explicitly to use the standard JDK libraries here.