### PR TITLE
Apply spotless by default for theme-plugin

### DIFF
--- a/theme-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/theme-plugin/src/main/resources/archetype-resources/pom.xml
@@ -16,7 +16,7 @@
 
   <name>$THEME_TITLE_NAME Theme Plugin</name>
 #if( $hostOnJenkinsGitHub == "true" )
-  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+  <url>https://github.com/${gitHubRepo}</url>
 
   <licenses>
     <license>
@@ -38,7 +38,11 @@
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>${jenkinsBaseline}</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+#if( $hostOnJenkinsGitHub == "true" )
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+#end
+
+    <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
   <dependencyManagement>
@@ -78,18 +82,6 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
@@ -102,4 +94,16 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/theme-plugin/src/main/resources/archetype-resources/src/main/java/__themeClassNameTheme.java
+++ b/theme-plugin/src/main/resources/archetype-resources/src/main/java/__themeClassNameTheme.java
@@ -21,9 +21,7 @@ public class $THEME_CLASS_NAMETheme extends ThemeManagerFactory {
 
     @Override
     public Theme getTheme() {
-        return Theme.builder()
-            .withCssUrls(List.of(getCssUrl()))
-            .build();
+        return Theme.builder().withCssUrls(List.of(getCssUrl())).build();
     }
 
     @Extension

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/java/jcasc/AbstractThemeJCasCTest.java
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/java/jcasc/AbstractThemeJCasCTest.java
@@ -26,36 +26,36 @@ import org.junit.jupiter.api.Test;
 @WithJenkinsConfiguredWithCode
 public abstract class AbstractThemeJCasCTest {
 
-  protected abstract Class<? extends ThemeManagerFactory> getThemeManagerFactory();
+    protected abstract Class<? extends ThemeManagerFactory> getThemeManagerFactory();
 
-  @Test
-  @ConfiguredWithCode("ConfigurationAsCode.yml")
-  void testConfig(JenkinsConfiguredWithCodeRule j) {
-    ThemeManagerPageDecorator decorator = ThemeManagerPageDecorator.get();
+    @Test
+    @ConfiguredWithCode("ConfigurationAsCode.yml")
+    void testConfig(JenkinsConfiguredWithCodeRule j) {
+        ThemeManagerPageDecorator decorator = ThemeManagerPageDecorator.get();
 
-    ThemeManagerFactory theme = decorator.getTheme();
-    assertNotNull(theme);
-    assertThat(decorator.isDisableUserThemes(), is(true));
-    assertThat(theme, instanceOf(getThemeManagerFactory()));
-  }
+        ThemeManagerFactory theme = decorator.getTheme();
+        assertNotNull(theme);
+        assertThat(decorator.isDisableUserThemes(), is(true));
+        assertThat(theme, instanceOf(getThemeManagerFactory()));
+    }
 
-  @Test
-  @ConfiguredWithCode("ConfigurationAsCode.yml")
-  void testExport(JenkinsConfiguredWithCodeRule j) throws Exception {
-    ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
-    CNode themeManager = getAppearanceRoot(context).get("themeManager");
+    @Test
+    @ConfiguredWithCode("ConfigurationAsCode.yml")
+    void testExport(JenkinsConfiguredWithCodeRule j) throws Exception {
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+        CNode themeManager = getAppearanceRoot(context).get("themeManager");
 
-    String exported = toYamlString(themeManager);
-    String expected = toStringFromYamlFile(this, "ConfigurationAsCodeExport.yml");
+        String exported = toYamlString(themeManager);
+        String expected = toStringFromYamlFile(this, "ConfigurationAsCodeExport.yml");
 
-    assertThat(exported, is(expected));
-  }
+        assertThat(exported, is(expected));
+    }
 
-  private static Mapping getAppearanceRoot(ConfigurationContext context) {
-    GlobalConfigurationCategory category =
-        ExtensionList.lookup(AppearanceCategory.class).get(0);
-    GlobalConfigurationCategoryConfigurator configurator = new GlobalConfigurationCategoryConfigurator(category);
-    GlobalConfigurationCategory target = configurator.getTargetComponent(context);
-    return Objects.requireNonNull(configurator.describe(target, context)).asMapping();
-  }
+    private static Mapping getAppearanceRoot(ConfigurationContext context) {
+        GlobalConfigurationCategory category =
+                ExtensionList.lookup(AppearanceCategory.class).get(0);
+        GlobalConfigurationCategoryConfigurator configurator = new GlobalConfigurationCategoryConfigurator(category);
+        GlobalConfigurationCategory target = configurator.getTargetComponent(context);
+        return Objects.requireNonNull(configurator.describe(target, context)).asMapping();
+    }
 }

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/AppearancePage.java
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/AppearancePage.java
@@ -43,7 +43,7 @@ public class AppearancePage extends JenkinsPage<AppearancePage> {
     private Locator getThemeCard(Theme theme) {
         log.debug("Locating theme box for '{}'", theme);
         return page.getByRole(AriaRole.RADIO, new GetByRoleOptions().setName(theme.name()))
-            .locator("..");
+                .locator("..");
     }
 
     /**
@@ -56,26 +56,26 @@ public class AppearancePage extends JenkinsPage<AppearancePage> {
         log.debug("Checking appearance for selector '{}' with CSS variable '{}'", selector, variable);
         try {
             page.waitForFunction(
-                """
+                    """
         ([selector, cssVar, expected]) => {
           const el = document.querySelector(selector);
           if (!el) return false;
           return getComputedStyle(el).getPropertyValue(cssVar).trim() === expected;
         }""",
-                List.of(selector, variable.name(), variable.expected()));
+                    List.of(selector, variable.name(), variable.expected()));
         } catch (TimeoutError e) {
             Object value = page.evaluate(
-                """
+                    """
                 ([selector, cssVar]) => {
                   const el = document.querySelector(selector);
                   if (!el) return null;
                   return getComputedStyle(el).getPropertyValue(cssVar).trim();
                 }""",
-                List.of(selector, variable.name()));
+                    List.of(selector, variable.name()));
             throw new AssertionError(
-                "Could not verify that '%s' was equal to '%s', found '%s'"
-                    .formatted(variable.name(), variable.expected(), value),
-                e);
+                    "Could not verify that '%s' was equal to '%s', found '%s'"
+                            .formatted(variable.name(), variable.expected(), value),
+                    e);
         }
     }
 }

--- a/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/__themeClassNameThemeTest.java
+++ b/theme-plugin/src/main/resources/archetype-resources/src/test/java/playwright/__themeClassNameThemeTest.java
@@ -10,13 +10,13 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 @UsePlaywright(PlaywrightConfig.class)
 public class $THEME_CLASS_NAMEThemeTest {
 
-  @Test
-  void themeLoads(JenkinsRule j, Page p) {
-    Theme theme = Theme.$THEME_CONSTANT_NAME;
-    new AppearancePage(p, j.jenkins.getRootUrl())
-        .goTo()
-        .themeIsPresent(theme)
-        .selectTheme(theme)
-        .themeIsApplied(theme);
-  }
+    @Test
+    void themeLoads(JenkinsRule j, Page p) {
+        Theme theme = Theme.$THEME_CONSTANT_NAME;
+        new AppearancePage(p, j.jenkins.getRootUrl())
+                .goTo()
+                .themeIsPresent(theme)
+                .selectTheme(theme)
+                .themeIsApplied(theme);
+    }
 }


### PR DESCRIPTION

<!-- Please describe your pull request here. -->

Ensure that projects generated by the theme plugin archetype have spotless applied by default.

This PR enables that setting as well as fixes up formatting issues within the archetype resources to ensure that there are no issues with the generated code.

### Testing done

`mvn clean verify`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
