### PR TITLE
Ban JUnit 4

### DIFF
--- a/empty-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/empty-plugin/src/main/resources/archetype-resources/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.19</version>
+    <version>5.21</version>
     <relativePath />
   </parent>
 
@@ -42,6 +42,7 @@
 #end
 
     <spotless.check.skip>false</spotless.check.skip>
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
   <dependencyManagement>

--- a/global-configuration/src/main/resources/archetype-resources/pom.xml
+++ b/global-configuration/src/main/resources/archetype-resources/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.19</version>
+    <version>5.21</version>
     <relativePath />
   </parent>
 
@@ -42,6 +42,7 @@
 #end
 
     <spotless.check.skip>false</spotless.check.skip>
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
   <dependencyManagement>

--- a/hello-world/src/main/resources/archetype-resources/pom.xml
+++ b/hello-world/src/main/resources/archetype-resources/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.19</version>
+    <version>5.21</version>
     <relativePath />
   </parent>
 
@@ -43,6 +43,7 @@
 #end
 
     <spotless.check.skip>false</spotless.check.skip>
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
   <dependencyManagement>

--- a/theme-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/theme-plugin/src/main/resources/archetype-resources/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.19</version>
+    <version>5.21</version>
     <relativePath />
   </parent>
 
@@ -43,6 +43,7 @@
 #end
 
     <spotless.check.skip>false</spotless.check.skip>
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Picks up the latest addition of the plugin pom, to stop the introduction of the deprecated library.